### PR TITLE
Bump Clojure version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ jdk:
   - openjdk7
   - oraclejdk8
 
-script: lein midje
+script: lein with-profile dev:dev,1.5:dev,1.6:dev,1.8 midje

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,4 @@
                    :global-vars {*warn-on-reflection* true}}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0-SNAPSHOT"]]}})
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0-alpha4"]]}})

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,6 @@
   :profiles {:dev {:dependencies [[midje "1.6.3"]]
                    :plugins [[lein-midje "3.1.3"]]
                    :global-vars {*warn-on-reflection* true}}
-             :clj-1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :clj-1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :clj-dev {:dependencies [[org.clojure/clojure "1.8.0-SNAPSHOT"]]}})
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0-SNAPSHOT"]]}})

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "http://mishok13.me/libs/syslog"
   :license {:name "MIT"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]]
   :profiles {:dev {:dependencies [[midje "1.6.3"]]
                    :plugins [[lein-midje "3.1.3"]]}})

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,8 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.7.0"]]
   :profiles {:dev {:dependencies [[midje "1.6.3"]]
-                   :plugins [[lein-midje "3.1.3"]]}})
+                   :plugins [[lein-midje "3.1.3"]]
+                   :global-vars {*warn-on-reflection* true}}
+             :clj-1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :clj-1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :clj-dev {:dependencies [[org.clojure/clojure "1.8.0-SNAPSHOT"]]}})


### PR DESCRIPTION
This pull request bumps default Clojure version to 1.7 and introduces 1.5, 1.6 and 1.8 profiles for testing.
